### PR TITLE
Move classes out of 'Ext' namespace

### DIFF
--- a/SqliteConnection.js
+++ b/SqliteConnection.js
@@ -1,7 +1,7 @@
 
 // var a = {dbName : "test",dbVersion : "1.0",dbDescription: "testdb",dbSize : 65536};
 
-Ext.define('Ext.Sqlite.Connection', {
+Ext.define('TomAlex0.data.proxy.SqliteConnection', {
     extend: 'Ext.util.Observable',
     /**
      * @cfg {String} dbName

--- a/SqliteStorage.js
+++ b/SqliteStorage.js
@@ -7,7 +7,7 @@
  * Ext.data.proxy.SqliteStorage sqlitestorage} proxies. It uses the  HTML5 Sqlite Database storage
  * save {@link Ext.data.Model model instances} for offline use.
  */
-Ext.define('Ext.data.proxy.SqliteStorage', {
+Ext.define('TomAlex0.data.proxy.SqliteStorage', {
     extend: 'Ext.data.proxy.Client',
     alias: 'proxy.sqlitestorage',
     alternateClassName: 'Ext.data.SqliteStorageProxy',

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
    	
     <script type="text/javascript" src="../../sencha-touch-all-debug.js"></script>
     <script type="text/javascript" src="SqliteConnection.js"></script>
-    <script type="text/javascript" src="SqliteProxy.js"></script>
+    <script type="text/javascript" src="SqliteStorage.js"></script>
     <script type="text/javascript" src="index.js"></script>
     <style type="text/css">
         .delete {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ Ext.setup({
 		};
 
 		//Ext.DbConnection = new Ext.Sqlite.Connection(dbconnval);
-		Ext.DbConnection = Ext.create('Ext.Sqlite.Connection',dbconnval);
+		Ext.DbConnection = Ext.create('TomAlex0.data.proxy.SqliteConnection',dbconnval);
 		
 		
 


### PR DESCRIPTION
The [Sencha Touch 2 docs](http://docs.sencha.com/touch/2-0/#!/guide/class_system) state that "Classes that are not distributed by Sencha should never use Ext as the top-level namespace." This commit renames the classes to not use the reserved `Ext` namespace and also matches up filenames with class names to make them compatible with `Ext.Loader` autoloading.
